### PR TITLE
Add support for windows

### DIFF
--- a/colcon_ed/edit_tools/__init__.py
+++ b/colcon_ed/edit_tools/__init__.py
@@ -79,10 +79,17 @@ def edit_target_file(path):
     :param str path: The path of the file to be edited
     :return: process return code
     """
-    editor = os.environ.get('EDITOR', 'vim')
-    if not editor:
-        editor = 'vim'
-    process = subprocess.Popen([editor, path])
+    process = None
+    if os.name == 'nt':
+        editor = os.getenv('EDITOR')
+        if not editor:
+            editor = 'vim'
+        process = subprocess.Popen([editor, path], shell=True)
+    else:
+        editor = os.environ.get('EDITOR', 'vim')
+        if not editor:
+            editor = 'vim'
+        process = subprocess.Popen([editor, path])
     while process.returncode is None:
         try:
             process.communicate()

--- a/colcon_ed/edit_tools/__init__.py
+++ b/colcon_ed/edit_tools/__init__.py
@@ -79,17 +79,11 @@ def edit_target_file(path):
     :param str path: The path of the file to be edited
     :return: process return code
     """
-    process = None
-    if os.name == 'nt':
-        editor = os.getenv('EDITOR')
-        if not editor:
-            editor = 'vim'
-        process = subprocess.Popen([editor, path], shell=True)
-    else:
-        editor = os.environ.get('EDITOR', 'vim')
-        if not editor:
-            editor = 'vim'
-        process = subprocess.Popen([editor, path])
+    editor = os.environ.get('EDITOR', 'vim')
+    if not editor:
+        editor = 'vim'
+    process = subprocess.Popen([editor, path],
+                               shell=(os.name == 'nt'))
     while process.returncode is None:
         try:
             process.communicate()


### PR DESCRIPTION
Working Windows support
- Add `shell=True` to run `Popen` on windows.
- Add environment variables support for windows. (WIP verify if `environ` works on Windows too)

Pipeline will pass after #17 is merged.