### PR TITLE
Make arguments required in argparse

### DIFF
--- a/colcon_ed/verb/edit.py
+++ b/colcon_ed/verb/edit.py
@@ -21,12 +21,12 @@ class EditVerb(VerbExtensionPoint):
 
     def add_arguments(self, *, parser):  # noqa: D102
         parser.add_argument(
-            'package_name', nargs='?', metavar='PKG_NAME',
+            'package_name', metavar='PKG_NAME',
             type=argument_package_name,
             help='Package name')
 
         args = parser.add_argument(
-            'filename', nargs='?', metavar='FILE_NAME',
+            'filename', metavar='FILE_NAME',
             type=argument_package_name,
             help='File name')
         args.completer = FileCompleter(package_name_key='package_name')

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -4,7 +4,6 @@ bainian
 colcon
 iterdir
 lstrip
-nargs
 noqa
 pathlib
 plugin


### PR DESCRIPTION
Currently, the arguments `PKG_NAME` and `FILE_NAME` are marked as optional in the argument parser but are actually required. When they are not set, the error message is currently `Package 'None' not found` or `File 'None' not found in package …`. This is not pretty and this PR changes it to printing the usage instructions.