### PR TITLE
Fix a flake8 E275 violation

### DIFF
--- a/colcon_ed/edit_tools/__init__.py
+++ b/colcon_ed/edit_tools/__init__.py
@@ -23,7 +23,7 @@ def get_package_path(package_name, args):
     descriptors = discover_packages(args, extensions)
     package_path = ''
     for pkg in descriptors:
-        if(pkg.name == args.package_name):
+        if pkg.name == args.package_name:
             package_path = pkg.path
     return package_path
 


### PR DESCRIPTION
```
_________________________________ test_flake8 __________________________________
test/test_flake8.py:50: in test_flake8
    assert not total_errors, \
E   AssertionError: flake8 reported 1 errors
E   assert not 1
----------------------------- Captured stdout call -----------------------------

1     E275 missing whitespace after keyword
----------------------------- Captured stderr call -----------------------------
src/colcon-ed/colcon_ed/edit_tools/__init__.py:26:11: E275 missing whitespace after keyword
        if(pkg.name == args.package_name):
          ^
flake8 reported 1 errors
```

Python 3.11.0
flake8 5.0.3